### PR TITLE
Fix issue with "Share list" button expanding space

### DIFF
--- a/pages/habit-lists/[id].js
+++ b/pages/habit-lists/[id].js
@@ -218,11 +218,11 @@ export default function List() {
           </div>
           <div>
             <h1 className='text-4xl font-bold text-center mt-6'> { listName } </h1>
-            <h3 className='mx-4 mt-6'> { message }</h3>
+            <h3 className='mx-4 mt-6 text-center'> { message }</h3>
           </div>  
           <div>
             <button 
-              className={`${ effect && `animate-wiggle`} bg-blue-500 hover:bg-blue-700 mr-20 mt-6 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline`}
+              className={`${ effect && `animate-wiggle`} bg-blue-500 hover:bg-blue-700 mr-20 mt-6 text-white font-bold w-28 h-10 rounded focus:outline-none focus:shadow-outline`}
               onClick={shareHabitButtonHandler}
               onAnimationEnd={() => setEffect(false)}
               >


### PR DESCRIPTION
When the "Share List" button is clicked, the text is converted to "URL Copied" and this expands the space of the button. This PR fixed that issue